### PR TITLE
AND-ing of query result

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ $(BIN)/tree_map.o:
 		$(BIN)/WAHQuery.o \
 		$(BIN)/SegUtil.o \
 		slave/slave.c \
-		-lpthread
+		-lpthread -lm
 
 .dbms:
 	@echo "Compiling DBMS"

--- a/dbms/dbms.c
+++ b/dbms/dbms.c
@@ -23,6 +23,16 @@ void test_put_vec_len_1(int queue_id, int vec_id, unsigned long long vec) {
     v->vector_length = 1;
     put_vector(queue_id, vec_id, v);
 }
+
+void test_put_vec_len_2(int queue_id, int vec_id, unsigned long long vec, unsigned long long vec2) {
+    vec_t *v = (vec_t *)malloc(sizeof(vec_t));
+    unsigned long long varr[] = {vec, vec2};
+    memcpy(v->vector, varr, sizeof(unsigned long long) * 2);
+    v->vector[0] = vec;
+    v->vector[1] = vec2;
+    v->vector_length = 2;
+    put_vector(queue_id, vec_id, v);
+}
 /**
  * Database Management System (DBMS)
  *
@@ -61,9 +71,23 @@ int main(int argc, char *argv[])
     test_put_vec_len_1(msq_id, 3, 0x0781);
     test_put_vec_len_1(msq_id, 4, 0x99ff);
 
+    test_put_vec_len_1(msq_id, 5, 43776);
+    test_put_vec_len_1(msq_id, 6, 49168);
+    test_put_vec_len_1(msq_id, 7, 0x8170);
+    test_put_vec_len_1(msq_id, 8, 0xff99);
+
+    test_put_vec_len_2(msq_id, 9, 867, 79425);
+    test_put_vec_len_2(msq_id, 10, 867, 53102);
+
+
     /* testing range query */
-    char range[] = "R:[1,4]";
+    printf("Range query\n");
+    char range[] = "R:[1,4]&[5,8]";
     range_query(msq_id, range);
+    char range2[] = "R:[1,2]&[3,4]&[5,6]";
+    range_query(msq_id, range2);
+    char range3[] = "R:[9,10]";
+    range_query(msq_id, range3);
     int master_result = 0;
     wait(&master_result);
 

--- a/master/master.c
+++ b/master/master.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
                 ];
                 */
                 if (NUM_SLAVES == 1) {
-                    commit_vector(request->vector.vec_id, request->vector.vec, SLAVE_ADDR, 1);
+                    commit_vector(request->vector.vec_id, request->vector.vec);
                 }
                 // TODO ensure slave_1 != slave_2 != slave_3
                 // TODO: call commit_vector RPC function here
@@ -159,7 +159,6 @@ int main(int argc, char *argv[])
                     }
                     free(machine_vec_ptrs);
                 }
-
                 init_range_query(range_array, contents.num_ranges, contents.ops, array_index);
             }
             else if (request->mtype == mtype_point_query) {

--- a/master/master_rq.c
+++ b/master/master_rq.c
@@ -22,9 +22,20 @@ int init_range_query(unsigned int *range_array, int num_ranges, char *ops, int a
         REMOTE_QUERY_ROOT_V1, "tcp");
     if (cl == NULL) {
         printf("Error: could not connect to coordinator %s.\n", coordinator);
+        return 1;
     }
+    printf("Calling RPC\n");
     query_result *res = rq_range_root_1(*root, cl);
-    printf("Result->vector.vector_val[0] is: %llu\n", res->vector.vector_val[0]);
+    if (res == NULL) {
+        printf("No response from coordinator.\n");
+        return 1;
+    }
+    int i;
+    printf("Result: \n");
+    for (i = 0; i < res->vector.vector_len - 1; i++) {
+        printf("%llu\n",res->vector.vector_val[i]);
+    }
+    printf("%llu\n", res->vector.vector_val[i]);
     free(root);
     return EXIT_SUCCESS;
 }

--- a/master/master_tpc_vector.c
+++ b/master/master_tpc_vector.c
@@ -20,45 +20,43 @@ typedef struct push_vec_args {
 
 /*
  * Commit the given vid:vector mappings to the given slaves.
+ * TODO: generalize this: have it take a set of machines instead, since they
+ * might not be available
  */
-int commit_vector(vec_id_t vec_id, vec_t vector, char **slaves, int num_slaves)
+int commit_vector(vec_id_t vec_id, vec_t vector)
 {
-    printf("in commit vec\n");
-    printf("in commit vector, slaves[0] = %s\n", SLAVE_ADDR[0]);
     /* 2PC Phase 1 on all Slaves */
-    pthread_t tids[num_slaves];
+    pthread_t tids[NUM_SLAVES];
     successes = 0;
     pthread_mutex_init(&lock, NULL);
 
     int i;
     void *status = 0;
-    printf("spawning threads, #slaves = %d\n", num_slaves);
-    for (i = 0; i < num_slaves; i++) {
+    for (i = 0; i < NUM_SLAVES; i++) {
         //printf("pthread create %s\n", slaves[i]);
         pthread_create(&tids[i], NULL, get_commit_resp, (void *)SLAVE_ADDR[i]);
     }
-    printf("joining threads\n");
-    for (i = 0; i < num_slaves; i++) {
+    for (i = 0; i < NUM_SLAVES; i++) {
         pthread_join(tids[i], &status);
         if (status == (void *) 1) {
-            printf("Failed to connect to all slaves.");
+            printf("Failed to connect to all slaves.\n");
             return 1;
         }
     }
 
     /* check if all slaves can commit */
-    if (successes != num_slaves) return 1;
+    if (successes != NUM_SLAVES) return 1;
 
     /* 2PC Phase 2 */
     i = 0;
-    for (i = 0; i < num_slaves; i++) {
+    for (i = 0; i < NUM_SLAVES; i++) {
         push_vec_args* ptr = (push_vec_args*) malloc(sizeof(push_vec_args));
         ptr->vector = vector;
         ptr->slave_addr = SLAVE_ADDR[i];
         ptr->vec_id = vec_id;
         pthread_create(&tids[i], NULL, push_vector, (void*) ptr);
     }
-    for (i = 0; i < num_slaves; i++) {
+    for (i = 0; i < NUM_SLAVES; i++) {
         pthread_join(tids[i], NULL);
     }
 
@@ -68,13 +66,10 @@ int commit_vector(vec_id_t vec_id, vec_t vector, char **slaves, int num_slaves)
 
 void *get_commit_resp(void *slv_addr_arg)
 {
-    printf("in gcr\n");
     char *slv_addr = (char *) slv_addr_arg;
     printf("Connecting to %s\n", slv_addr);
     CLIENT* clnt = clnt_create(slv_addr, TWO_PHASE_COMMIT_VOTE,
         TWO_PHASE_COMMIT_VOTE_V1, "tcp");
-    printf("Created clnt\n");
-
 
     if (clnt == NULL) {
         printf("Error: could not connect to slave %s.\n", slv_addr);
@@ -84,9 +79,7 @@ void *get_commit_resp(void *slv_addr_arg)
     struct timeval tv;
     tv.tv_sec = TIME_TO_VOTE;
     tv.tv_usec = 0;
-    printf("client control pn %d\n", clnt == NULL);
     clnt_control(clnt, CLSET_TIMEOUT, &tv);
-    printf("About to connect\n");
     int *result = commit_msg_1(0, clnt);
 
     if (result == NULL || *result == VOTE_ABORT) {
@@ -97,6 +90,7 @@ void *get_commit_resp(void *slv_addr_arg)
         successes++;
         pthread_mutex_unlock(&lock);
     }
+    clnt_destroy(clnt);
     return (void*) 0;
 }
 
@@ -112,7 +106,6 @@ void *push_vector(void *thread_arg)
     }
 
     commit_vec_args *a = (commit_vec_args*) malloc(sizeof(commit_vec_args));
-	printf("Committing vector %u\n", a->vec_id);
     a->vec_id = args->vec_id;
     a->vector.vector_val = args->vector.vector;
     a->vector.vector_len = args->vector.vector_length;

--- a/master/tpc_master.h
+++ b/master/tpc_master.h
@@ -1,5 +1,5 @@
 /* master_tpc_vector.c functions */
 #include "../types/types.h"
-int commit_vector(vec_id_t , vec_t , char **, int );
+int commit_vector(vec_id_t, vec_t);
 void *get_commit_resp(void*);
 void *push_vector(void*);

--- a/rpc/src/slave.x
+++ b/rpc/src/slave.x
@@ -23,6 +23,7 @@ struct rq_pipe_args {
 struct query_result {
     unsigned hyper int vector<>;
     unsigned int exit_code;
+    string error_message<128>;
 };
 
 program REMOTE_QUERY_PIPE {


### PR DESCRIPTION
Finished the querying process by AND-ing the results. Future iterations should be generalized to `&` or `|` the results, but all of the tests in `BitmapWorkloadGenerator` make queries containing only `&`.

Other changes:
- Added some new tests in `dbms.c` on vectors length 2.
- Fixed bug in `commit_vec_1_svc` (not writing to file correctly)
- Lesson learned the hard way: when returning an RPC struct, every field has to be non-`NULL`, otherwise a segmentation fault occurs.

I also added a couple issues that I discovered as I was making these changes (see `distributed-system` and `Bitmap-Engine` repos for those)