### PR TITLE
rebalancing fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ gen/
 
 # python output
 __pycache__
+
+# macOS Finder file
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -81,5 +81,5 @@ basic_test: all
 # Voting data test
 vd_test: all
 	@echo "Creating test data..."
-	@cd tst_data && python3 convert_voting_data.py
+	@cd tst_data/rep-votes && python3 convert_voting_data.py
 	@cd bin/ && ./dbms 1

--- a/consistent-hash/ring/src/tree_map.c
+++ b/consistent-hash/ring/src/tree_map.c
@@ -59,11 +59,13 @@ static int replication_factor = 2;
 cache_id *ring_get_machines_for_vector(rbt_ptr t, unsigned int vec_id)
 {
     // ideally this should be a for-loop
-    node_ptr n1 = succ(t, hash(vec_id));
-    node_ptr n2 = succ(t, hash(vec_id + 1));
+    // node_ptr n1 = succ(t, hash(vec_id));
+    // node_ptr n2 = succ(t, hash(vec_id + 1));
     cache_id *res = (cache_id *) malloc(sizeof(cache_id) * replication_factor);
-    res[0] = n1->cid;
-    res[1] = n2->cid;
+    node_ptr primary_node = succ(t, hash(vec_id));
+    node_ptr backup_node = succ(t, primary_node->hv);
+    res[0] = primary_node->cid;
+    res[1] = backup_node->cid;
     return res;
 }
 

--- a/master/master.h
+++ b/master/master.h
@@ -18,7 +18,8 @@ typedef struct slave {
     unsigned int id;
     char *address;
     bool is_alive;
-    slave_vector *vectors;
+    slave_vector *primary_vector_head; /* vectors that were assigned to this slave */
+    slave_vector *primary_vector_tail;
 } slave;
 
 typedef struct slave_ll {
@@ -35,8 +36,8 @@ static int replication_factor = 2;
 /* master function prototypes */
 int setup_slave(slave*);
 slave *new_slave(char*);
-void heartbeat(void);
-int is_alive(char *);
+int heartbeat(void);
+bool is_alive(char *);
 unsigned int *get_machines_for_vector(unsigned int);
 int send_vector(slave *, vec_id_t, slave*);
 void reallocate(void);

--- a/master/master_tpc_vector.c
+++ b/master/master_tpc_vector.c
@@ -34,7 +34,7 @@ int commit_vector(vec_id_t vec_id, vec_t vector, slave *slaves[], int num_slaves
     for (i = 0; i < num_slaves; i++) {
         //printf("pthread create %s\n", slaves[i]);
         pthread_create(&tids[i], NULL, get_commit_resp,
-            (void *)slaves[i]->address);
+            (void *) slaves[i]->address);
     }
 
     for (i = 0; i < num_slaves; i++) {

--- a/master/master_tpc_vector.c
+++ b/master/master_tpc_vector.c
@@ -25,7 +25,7 @@ typedef struct push_vec_args {
 int commit_vector(vec_id_t vec_id, vec_t vector, slave *slaves[], int num_slaves)
 {
     /* 2PC Phase 1 on all Slaves */
-    pthread_t tids[NUM_SLAVES];
+    pthread_t tids[num_slaves];
     successes = 0;
     pthread_mutex_init(&lock, NULL);
 
@@ -33,7 +33,8 @@ int commit_vector(vec_id_t vec_id, vec_t vector, slave *slaves[], int num_slaves
     void *status = 0;
     for (i = 0; i < num_slaves; i++) {
         //printf("pthread create %s\n", slaves[i]);
-        pthread_create(&tids[i], NULL, get_commit_resp, (void *)slaves[i]->address);
+        pthread_create(&tids[i], NULL, get_commit_resp,
+            (void *)slaves[i]->address);
     }
 
     for (i = 0; i < num_slaves; i++) {
@@ -68,10 +69,9 @@ int commit_vector(vec_id_t vec_id, vec_t vector, slave *slaves[], int num_slaves
 void *get_commit_resp(void *slv_addr_arg)
 {
     char *slv_addr = (char *) slv_addr_arg;
-    printf("Connecting to %s\n", slv_addr);
-    CLIENT* clnt = clnt_create(slv_addr, TWO_PHASE_COMMIT_VOTE,
-        TWO_PHASE_COMMIT_VOTE_V1, "tcp");
-
+    printf("Connecting to %s, creating clnt\n", slv_addr);
+    CLIENT *clnt = clnt_create(slv_addr, TWO_PHASE_COMMIT,
+        TWO_PHASE_COMMIT_V1, "tcp");
     if (clnt == NULL) {
         printf("Error: could not connect to slave %s.\n", slv_addr);
         pthread_exit((void*) 1);
@@ -82,7 +82,6 @@ void *get_commit_resp(void *slv_addr_arg)
     tv.tv_usec = 0;
     clnt_control(clnt, CLSET_TIMEOUT, &tv);
     int *result = commit_msg_1(0, clnt);
-
     if (result == NULL || *result == VOTE_ABORT) {
         printf("Couldn't commit at slave %s.\n", slv_addr);
     }
@@ -98,8 +97,8 @@ void *get_commit_resp(void *slv_addr_arg)
 void *push_vector(void *thread_arg)
 {
     push_vec_args *args = (push_vec_args *) thread_arg;
-    CLIENT* cl = clnt_create(args->slave_addr, TWO_PHASE_COMMIT_VEC,
-        TPC_COMMIT_VEC_V1, "tcp");
+    CLIENT* cl = clnt_create(args->slave_addr, TWO_PHASE_COMMIT,
+        TWO_PHASE_COMMIT_V1, "tcp");
 
     if (cl == NULL) {
         printf("Error: could not connect to slave %s.\n", args->slave_addr);
@@ -131,9 +130,14 @@ int setup_slave(slave *slv)
         printf("Error: couldn't connect\n");
         return 1;
     }
-    init_slave_args *args = (init_slave_args *) malloc(sizeof(init_slave_args));
+    init_slave_args *args = (init_slave_args *)
+        malloc(sizeof(init_slave_args));
     args->machine_name = slv->address;
     args->slave_id = slv->id;
+    struct timeval tv;
+    tv.tv_sec = 1; // TODO: it is important to come up with a reasonable value for this!
+    tv.tv_usec = 0;
+    clnt_control(cl, CLSET_TIMEOUT, &tv);
     int *res = init_slave_1(*args, cl);
     free(args);
     clnt_destroy(cl);
@@ -147,11 +151,11 @@ int setup_slave(slave *slv)
 /**
  * Ask the slave at the given node if it's alive
  */
-int is_alive(char *address)
+bool is_alive(char *address)
 {
     CLIENT *cl = clnt_create(address, AYA, AYA_V1, "tcp");
     if (cl == NULL) {
-        return 1;
+        return false;
     }
     struct timeval tv;
     tv.tv_sec = 1; // TODO: it is important to come up with a reasonable value for this!
@@ -159,10 +163,10 @@ int is_alive(char *address)
     clnt_control(cl, CLSET_TIMEOUT, &tv);
     int *res = stayin_alive_1(0, cl);
     if (*res) {
-        return 1;
+        return false;
     }
     clnt_destroy(cl);
-    return 0;
+    return true;
 }
 
 int send_vector(slave *slave_1, vec_id_t vec_id, slave *slave_2)
@@ -179,7 +183,8 @@ int send_vector(slave *slave_1, vec_id_t vec_id, slave *slave_2)
     copy_vector_args args;
     args.vec_id = vec_id;
     char *addr = slave_2->address;
-    memcpy(args.destination_addr, addr, (strlen(addr) + 1) * sizeof(char));
+    args.destination_addr = (char *) malloc(sizeof(addr));
+    strcpy(args.destination_addr, addr);
     int *res = send_vec_1(args, cl);
     clnt_destroy(cl);
     //free(args);

--- a/rpc/src/slave.x
+++ b/rpc/src/slave.x
@@ -60,18 +60,12 @@ struct commit_vec_args {
     unsigned hyper int vector<>;
 };
 
-program TWO_PHASE_COMMIT_VOTE {
-    version TWO_PHASE_COMMIT_VOTE_V1 {
+program TWO_PHASE_COMMIT {
+    version TWO_PHASE_COMMIT_V1 {
         int COMMIT_MSG(int x) = 1;
+        int COMMIT_VEC(struct commit_vec_args) = 2;
     } = 1;
 } = 0x30;
-
-program TWO_PHASE_COMMIT_VEC {
-    version TPC_COMMIT_VEC_V1 {
-        int COMMIT_VEC(struct commit_vec_args) = 1;
-    } = 1;
-} = 0x40;
-
 
 struct init_slave_args {
     unsigned int slave_id;

--- a/slave/slave.c
+++ b/slave/slave.c
@@ -235,7 +235,8 @@ rq_range_root_1_svc(rq_range_root_args query, struct svc_req *req)
         if (results[i]->exit_code != EXIT_SUCCESS) {
             res->exit_code = results[i]->exit_code;
             char *msg = results[i]->error_message;
-            memcpy(res->error_message, msg, (strlen(msg) + 1) * sizeof(char));
+            res->error_message = (char *) malloc(sizeof(msg));
+            strcpy(res->error_message, msg);
             res->failed_machine_id = results[i]->failed_machine_id;
             free_res(num_threads);
             return res;
@@ -327,6 +328,7 @@ int *init_slave_1_svc(init_slave_args args, struct svc_req *req)
 {
     slave_id = args.slave_id; /* assign this slave its ID */
     result = EXIT_SUCCESS;
+    printf("Registered slave %d\n", slave_id);
     return &result;
 }
 
@@ -342,8 +344,8 @@ int *stayin_alive_1_svc(int x, struct svc_req *req)
  */
 int *send_vec_1_svc(copy_vector_args copy_args, struct svc_req *req)
 {
-    CLIENT *cl = clnt_create(copy_args.destination_addr, TWO_PHASE_COMMIT_VEC,
-        TPC_COMMIT_VEC_V1, "tcp");
+    CLIENT *cl = clnt_create(copy_args.destination_addr, TWO_PHASE_COMMIT,
+        TWO_PHASE_COMMIT_V1, "tcp");
     commit_vec_args args;
     args.vec_id = copy_args.vec_id;
     query_result *qres = get_vector(copy_args.vec_id);

--- a/types/types.h
+++ b/types/types.h
@@ -3,7 +3,7 @@
  */
 #ifndef TYPES_H
 #define TYPES_H
-#define MAX_VECTOR_LEN 32
+#define MAX_VECTOR_LEN 128
 typedef struct vec_t {
     unsigned long long vector[MAX_VECTOR_LEN];
     unsigned int vector_length;


### PR DESCRIPTION
- fixed filepath on `rep-votes` test
- fixed rebalacing function (getting successor slave correctly and updating linked-lists of primary vectors)
- consolidated TPC RPC (this is causing problems in macOS, see #29)